### PR TITLE
Equal assign r36 bug

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 
 # devel
 
+* Ensure that closing xml-tags for code expressions that end at the same
+  position in a file respect start-first-end-last ordering in the produced xml.
+  Ensures that the new `equal_assign` token in `getParseData()` for R-3.6 is
+  handled appropriately. #5 @russHyde
+
 # 1.0.2
 
 * Remove control characters `\003`, `\007`, `\010`, `\027`, as they are

--- a/R/package.R
+++ b/R/package.R
@@ -107,7 +107,11 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
   }
 
   ## Order the nodes properly
-  pd <- pd[ order(pd$line1, pd$col1, -pd$line2, -pd$col2, pd$terminal), ]
+  ## - the terminal nodes from pd2 may be nested inside each other, when
+  ##   this happens they will have the same line1, col1, line2, col2 and
+  ##   terminal status; and 'start' is used to break ties
+  ord <- with(pd, order(line1, col1, -line2, -col2, terminal, -start))
+  pd <- pd[ord, ]
 
   if (pretty) {
     str <- ! pd$terminal

--- a/R/package.R
+++ b/R/package.R
@@ -110,7 +110,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
   ## - the terminal nodes from pd2 may be nested inside each other, when
   ##   this happens they will have the same line1, col1, line2, col2 and
   ##   terminal status; and 'start' is used to break ties
-  ord <- with(pd, order(line1, col1, -line2, -col2, terminal, -start))
+  ord <- order(pd$line1, pd$col1, -pd$line2, -pd$col2, pd$terminal, -pd$start)
   pd <- pd[ord, ]
 
   if (pretty) {

--- a/tests/testthat/test-debug_equals_assign.R
+++ b/tests/testthat/test-debug_equals_assign.R
@@ -1,42 +1,11 @@
 context("debugging `a = 1` bug in R3.6")
 
 test_that("equals_assign bug on R 3.6", {
-  # in R3.6 the xml for `a = 1` originally came out as:
-  # <exprlist>
-  #   <equal_assign ...>
-  #     <expr ...>
-  #       <SYMBOL ...>a</SYMBOL>
-  #     </expr>
-  #     <EQ_ASSIGN ...>=</EQ_ASSIGN>
-  #     <expr ...>
-  #       <NUM_CONST ...>1</NUM_CONST>
-  #     </equal_assign>
-  #   </expr>
-  # </exprlist>
-
-  # in R3.5 the same code gave
-  # ...
-  # <exprlist>
-  #   <expr ...>
-  #     <SYMBOL ...>a</SYMBOL>
-  #   </expr>
-  #   <EQ_ASSIGN ...>=</EQ_ASSIGN>
-  #   <expr ...>
-  #     <NUM_CONST ...>1</NUM_CONST>
-  #   </expr>
-  # </exprlist>
-
-  # The tags have changed:
-  # -  R3.6 intends to wrap the whole assignment statement using the tagname
-  # `equal_assign` (whereas R3.5 uses `expr`)
-
-  # But also, the xml parsing in R3.6 has interleaved the `equal_assign` tag
-  # with the final `expr` tag; resulting in an illegal xml string
-
-  # `equal_assign` nodes in results from getParseData() mean that `expr` nodes
-  # can be nested inside `equal_assign` nodes in such a way that the start of
-  # one nested-node matches the start of the equal_assign node, and the end of
-  # a nested-node matches the end of the equal_assign node.
+  # `a = 1` is an example of an R statement that gets parsed into nested xml
+  # nodes that have different token / tagnames (following the introduction of
+  # the `equal_assign` token to getParseData() in R-3.6), but the same ending
+  # position in the original code. Tokens/expressions that start before should
+  # end after any nested subexpressions in the resulting xml:
 
   xml <- xml_parse_data(parse(text = "a = 1", keep.source = TRUE))
   expect_true(is.character(xml))

--- a/tests/testthat/test-debug_equals_assign.R
+++ b/tests/testthat/test-debug_equals_assign.R
@@ -1,0 +1,46 @@
+context("debugging `a = 1` bug in R3.6")
+
+test_that("equals_assign bug on R 3.6", {
+  # in R3.6 the xml for `a = 1` originally came out as:
+  # <exprlist>
+  #   <equal_assign ...>
+  #     <expr ...>
+  #       <SYMBOL ...>a</SYMBOL>
+  #     </expr>
+  #     <EQ_ASSIGN ...>=</EQ_ASSIGN>
+  #     <expr ...>
+  #       <NUM_CONST ...>1</NUM_CONST>
+  #     </equal_assign>
+  #   </expr>
+  # </exprlist>
+
+  # in R3.5 the same code gave
+  # ...
+  # <exprlist>
+  #   <expr ...>
+  #     <SYMBOL ...>a</SYMBOL>
+  #   </expr>
+  #   <EQ_ASSIGN ...>=</EQ_ASSIGN>
+  #   <expr ...>
+  #     <NUM_CONST ...>1</NUM_CONST>
+  #   </expr>
+  # </exprlist>
+
+  # The tags have changed:
+  # -  R3.6 intends to wrap the whole assignment statement using the tagname
+  # `equal_assign` (whereas R3.5 uses `expr`)
+
+  # But also, the xml parsing in R3.6 has interleaved the `equal_assign` tag
+  # with the final `expr` tag; resulting in an illegal xml string
+
+  # `equal_assign` nodes in results from getParseData() mean that `expr` nodes
+  # can be nested inside `equal_assign` nodes in such a way that the start of
+  # one nested-node matches the start of the equal_assign node, and the end of
+  # a nested-node matches the end of the equal_assign node.
+
+  xml <- xml_parse_data(parse(text = "a = 1", keep.source = TRUE))
+  expect_true(is.character(xml))
+  expect_true(length(xml) == 1)
+  expect_silent(x <- xml2::read_xml(xml))
+})
+

--- a/tests/testthat/test-debug_equals_assign.R
+++ b/tests/testthat/test-debug_equals_assign.R
@@ -1,15 +1,3 @@
 context("debugging `a = 1` bug in R3.6")
 
-test_that("equals_assign bug on R 3.6", {
-  # `a = 1` is an example of an R statement that gets parsed into nested xml
-  # nodes that have different token / tagnames (following the introduction of
-  # the `equal_assign` token to getParseData() in R-3.6), but the same ending
-  # position in the original code. Tokens/expressions that start before should
-  # end after any nested subexpressions in the resulting xml:
-
-  xml <- xml_parse_data(parse(text = "a = 1", keep.source = TRUE))
-  expect_true(is.character(xml))
-  expect_true(length(xml) == 1)
-  expect_silent(x <- xml2::read_xml(xml))
-})
 

--- a/tests/testthat/test-debug_equals_assign.R
+++ b/tests/testthat/test-debug_equals_assign.R
@@ -1,3 +1,0 @@
-context("debugging `a = 1` bug in R3.6")
-
-

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -94,7 +94,6 @@ test_that("data frame input", {
 })
 
 
-
 test_that("Control-C character", {
   src <- "# Control-C \003
           # Bell  \007
@@ -103,5 +102,19 @@ test_that("Control-C character", {
   xml <- xml_parse_data(parse(text = src, keep.source = TRUE))
   x <- xml2::read_xml(xml)
   expect_is(x, "xml_document")
+})
+
+
+test_that("equal_assign is handled on R 3.6", {
+  # `a = 1` is an example of an R statement that gets parsed into nested xml
+  # nodes that have different token / tagnames (following the introduction of
+  # the `equal_assign` token to getParseData() in R-3.6), but the same ending
+  # position in the original code. Tokens/expressions that start before should
+  # end after any nested subexpressions in the resulting xml:
+
+  xml <- xml_parse_data(parse(text = "a = 1", keep.source = TRUE))
+  expect_true(is.character(xml))
+  expect_true(length(xml) == 1)
+  expect_silent(x <- xml2::read_xml(xml))
 })
 


### PR DESCRIPTION
Following up on a bug in R3.6 https://github.com/r-lib/xmlparsedata/issues/5
that meant `xml_parse_data(parse(text = "a = 1"))` couldn't be converted
to valid xml (although this could be parsed in R3.5 using `xml_parse_data`).

This appears to result from changes to `getParseData` in R3.6.

    Expressions can be nested inside each other in the data returned by
    getParseData() in such a way that the end position of the nested
    expressions are identical.
    
    For example, the code above gets parsed into the following subtree
    (approximately) by getParseData(). In it, `equal_assign` and `expr[2]`
    end at the same position in the code above (relevant in R3.6).
    - equal_assign:
        - expr[1]:
            - SOME_SYMBOL
        - EQ_ASSIGN
        - expr[2]:
            - SOME_VALUE
    
    xml-termini for `equal_assign` and both `expr` nodes are added
    while running xml_parse_data; but these termini were originally
    sorted such that that for `equal_assign` came before the second
    `expr`. Like: `<equal_assign>...<expr[2]></equal_assign></expr[2]>`.
    
    The xml-termini for each expression are now sorted by the start
    position of the expressions (in addition to their other
    coordinates).

[not sure I've explained the problem / fix particularly well; apologies]