### PR TITLE
Fix missing space in XML header

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -54,7 +54,7 @@ NULL
 xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
 
   xml_header <- paste0(
-    "<?xml version=\"1.0\" encoding=\"UTF-8\"",
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" ",
     "standalone=\"yes\" ?>\n<exprlist>\n"
   )
   xml_footer <- "\n</exprlist>\n"


### PR DESCRIPTION
XML validator complains the missing space in the XML header produced by `xml_parse_data`.

```xml
<?xml version="1.0" encoding="UTF-8"standalone="yes" ?>
```

should be 

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
```