### PR TITLE
Fix includeText=FALSE

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 
 * Translate ] tokens to `OP-RIGHT-BRACKET` instead of `OP-RIGHT-BRACE`. #11 @AshesITR
 
+* Fix `includeText=FALSE`. #14 @renkun-ken
+
 # 1.0.3
 
 * Ensure that closing xml-tags for code expressions that end at the same

--- a/R/package.R
+++ b/R/package.R
@@ -70,7 +70,10 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
   if (!nrow(pd)) return(paste0(xml_header, xml_footer))
 
   pd <- fix_comments(pd)
-  pd$text <-  enc2utf8(pd$text)
+
+  if (!is.null(pd$text)) {
+    pd$text <- enc2utf8(pd$text)
+  }
 
   ## Tags for all nodes, teminal nodes have end tags as well
   pd$token <- map_token(pd$token)
@@ -89,7 +92,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
     "\" start=\"", pd$start,
     "\" end=\"", pd$end,
     "\">",
-    xml_encode(pd$text),
+    if (!is.null(pd$text)) xml_encode(pd$text) else "",
     ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
   )
 

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -118,3 +118,15 @@ test_that("equal_assign is handled on R 3.6", {
   expect_silent(x <- xml2::read_xml(xml))
 })
 
+test_that("includeText=FALSE works", {
+  # getParseData(..., includeText = FALSE) returns a data.frame
+  # without `text` column. xml_parse_data should handle this case
+  # correctly and the resulting xml text should not contain text
+  # elements.
+  xml <- xml_parse_data(parse(text = "x <- 1", keep.source = TRUE),
+    includeText = FALSE)
+  expect_true(is.character(xml))
+  expect_true(length(xml) == 1)
+  expect_silent(x <- xml2::read_xml(xml))
+  expect_true(xml2::xml_text(x) == "")
+})


### PR DESCRIPTION
Closes #13 

This PR adds some checking of `pd$text` to make `includeText=FALSE` work.