### PR TITLE
Add OP-LAMBDA to xml_parse_token_map

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,8 @@
 
 # 1.0.4.9000
 
+* Translate `\` in lambda expression to `OP-LAMBDA`. (#18 @renkun-ken)
+
 # 1.0.4
 
 * Translate ] tokens to `OP-RIGHT-BRACKET` instead of

--- a/R/package.R
+++ b/R/package.R
@@ -168,7 +168,8 @@ xml_parse_token_map <- c(
   "')'" = "OP-RIGHT-PAREN",
   "'!'" = "OP-EXCLAMATION",
   "']'" = "OP-RIGHT-BRACKET",
-  "','" = "OP-COMMA"
+  "','" = "OP-COMMA",
+  "'\\\\'" = "OP-LAMBDA"
 )
 
 xml_encode <- function(x) {

--- a/man/xml_parse_token_map.Rd
+++ b/man/xml_parse_token_map.Rd
@@ -5,7 +5,7 @@
 \alias{xml_parse_token_map}
 \title{Map token names of the R parser to token names in
 \code{\link{xml_parse_data}}}
-\format{An object of class \code{character} of length 19.}
+\format{An object of class \code{character} of length 20.}
 \usage{
 xml_parse_token_map
 }

--- a/tests/testthat/test.R
+++ b/tests/testthat/test.R
@@ -130,3 +130,13 @@ test_that("includeText=FALSE works", {
   expect_silent(x <- xml2::read_xml(xml))
   expect_true(xml2::xml_text(x) == "")
 })
+
+test_that("lambda operator works", {
+  testthat::skip_if_not(getRversion() >= "4.1.0" && as.numeric(R.version[["svn rev"]]) >= 79553)
+  # r-devel rev 79553 introduces native pipe syntax (|>) and lambda expression (e.g \(x) x + 1).
+  xml <- xml_parse_data(parse(text = "\\(x) x + 1"))
+  expect_true(is.character(xml))
+  expect_true(length(xml) == 1)
+  expect_silent(x <- xml2::read_xml(xml))
+  expect_true(length(xml2::xml_find_all(x, "//OP-LAMBDA")) == 1)
+})


### PR DESCRIPTION
Closes #17 

This PR adds `"'\\\\'" = "OP-LAMBDA"` to `xml_parse_token_map` so that `xml_parse_data` could produce valid XML when the source code use the newly introduced lambda syntax.
