### PR TITLE
Add package name for pkgdown::build_news()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,13 +1,13 @@
 
-# Development version
+# xmlparsedata Development version
 
-# 1.0.5
+# xmlparsedata 1.0.5
 
 * Translate `\` in lambda expression to `OP-LAMBDA` (#18 @renkun-ken).
 
 * Drop all control characters, except horizontal tab and newline (#19).
 
-# 1.0.4
+# xmlparsedata 1.0.4
 
 * Translate ] tokens to `OP-RIGHT-BRACKET` instead of
   `OP-RIGHT-BRACE` (#11 @AshesITR).
@@ -15,21 +15,21 @@
 * `xml_parse_data()` now works if `includeText = FALSE`
   (#14 @renkun-ken).
 
-# 1.0.3
+# xmlparsedata 1.0.3
 
 * Ensure that closing xml-tags for code expressions that end at the same
   position in a file respect start-first-end-last ordering in the produced xml.
   Ensures that the new `equal_assign` token in `getParseData()` for R-3.6 is
   handled appropriately. #5 @russHyde
 
-# 1.0.2
+# xmlparsedata 1.0.2
 
 * Remove control characters `\003`, `\007`, `\010`, `\027`, as they are
   not allowed in XML 1.0, #1 @GregoireGauriot
 
 * Always convert parsed text to UTF-8
 
-# 1.0.1
+# xmlparsedata 1.0.1
 
 * Fix a bug when the input is already a `getParseData()` data frame.
   https://github.com/jimhester/lintr filters the parsed data to include
@@ -38,6 +38,6 @@
   again, we get the data for the whole source file. This is fixed now by
   noticing that the input is already a data frame
 
-# 1.0.0
+# xmlparsedata 1.0.0
 
 First public release.


### PR DESCRIPTION
At the moment the news page in the pkgdown website is empty. 

Cf https://pkgdown.r-lib.org/reference/build_news.html