### PR TITLE
Remove spaces() helper in favor of using strrep

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -123,7 +123,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
     str <- !pd$terminal
     end <- pd$parent == -1
     ind <- 2L + cumsum(str * 2L + end * (-2L)) - str * 2L
-    xml <- paste0(spaces(ind), pd$tag, collapse = "\n")
+    xml <- paste0(strrep(" ", ind), pd$tag, collapse = "\n")
   } else {
     xml <- paste(pd$tag, collapse = "\n")
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,1 +1,0 @@
-spaces <- function(x) strrep(" ", x)

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,4 +1,1 @@
-
-spaces_const <- sapply(1:41 - 1, function(x) paste(rep(" ", x), collapse = ""))
-
-spaces <- function(x) spaces_const[pmin(x, 40) + 1]
+spaces <- function(x) strrep(" ", x)


### PR DESCRIPTION
d8fc6d2d4770afae7e44bb76d6a2ccbcd692be3d uses `strrep()` in the helper to retain the "caching" approach, but caching shouldn't have any benefit thanks to the global string cache as `strrep()` is already vectorized in `times=`.