### PR TITLE
xml_parse_data works when keep.source=FALSE

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -95,18 +95,26 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
   pd$start <- pd$line1 * maxcol + pd$col1
   pd$end <- pd$line2 * maxcol + pd$col2
 
-  pd$tag <- paste0(
-    "<", pd$token,
-    " line1=\"", pd$line1,
-    "\" col1=\"", pd$col1,
-    "\" line2=\"", pd$line2,
-    "\" col2=\"", pd$col2,
-    "\" start=\"", pd$start,
-    "\" end=\"", pd$end,
-    "\">",
-    if (!is.null(pd$text)) xml_encode(pd$text) else "",
-    ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
-  )
+  if (anyNA(pd$line1)) {
+    pd$tag <- paste0(
+      "<", pd$token, ">",
+      if (!is.null(pd$text)) xml_encode(pd$text) else "",
+      ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
+    )
+  } else {
+    pd$tag <- paste0(
+      "<", pd$token,
+      " line1=\"", pd$line1,
+      "\" col1=\"", pd$col1,
+      "\" line2=\"", pd$line2,
+      "\" col2=\"", pd$col2,
+      "\" start=\"", pd$start,
+      "\" end=\"", pd$end,
+      "\">",
+      if (!is.null(pd$text)) xml_encode(pd$text) else "",
+      ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
+    )
+  }
 
   ## Add an extra terminal tag for each non-terminal one
   pd2 <- pd[!pd$terminal, ]

--- a/R/package.R
+++ b/R/package.R
@@ -66,6 +66,15 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
     pd <- x
   } else {
     pd <- getParseData(x, includeText = includeText)
+    if (is.null(pd)) {
+      tmp_source <- tempfile()
+      on.exit(unlink(tmp_source))
+      dput(x, file = tmp_source)
+
+      x <- parse(tmp_source, keep.source = TRUE)
+      pd <- getParseData(x, includeText = includeText)
+      pd$line1 <- pd$line2 <- pd$col1 <- pd$col2 <- NA_integer_
+    }
   }
 
   if (!nrow(pd)) {


### PR DESCRIPTION
Filing for initial feedback.

This is the simplest version that works, e.g.

```r
xml_parse_data(parse(text = "1 + 1", keep.source=FALSE), pretty = TRUE) |> writeLines()
```

gives

```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>
<exprlist>
  <expr line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">
    <expr line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">
      <expr line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">
        <expr line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">
          <expr line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">
            <SYMBOL_FUNCTION_CALL line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">expression</SYMBOL_FUNCTION_CALL>
            <OP-LEFT-PAREN line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">(</OP-LEFT-PAREN>
            <NUM_CONST line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">1</NUM_CONST>
            <OP-PLUS line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">+</OP-PLUS>
            <NUM_CONST line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">1</NUM_CONST>
            <OP-RIGHT-PAREN line1="NA" col1="NA" line2="NA" col2="NA" start="NA" end="NA">)</OP-RIGHT-PAREN>
          </expr>
        </expr>
      </expr>
    </expr>
  </expr>
</exprlist>
```

But string `"NA"` for the attributes may be unappealing (since `as.integer()` throws a warning). It may be better to drop those `"NA"` attributes altogether, WDYT?