### PR TITLE
clarify octal escapes NEWS item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 # xmlparsedata Development version
 
 * Re-parse character literals with octal-escaped expressions of width 1 or 2,
-  e.g. `"\1"`, to work around a bug (in R<4.2.1) in `utils::getParseData()`
+  e.g. `"\1"`, to work around a bug (in R<4.3.0) in `utils::getParseData()`
   (#25, @michaelchirico).
 
 * New `expr_as_xml()` to get an XML representation of R expressions (#27 @MichaelChirico).

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 # xmlparsedata Development version
 
 * Re-parse character literals with octal-escaped expressions of width 1 or 2,
-  e.g. `"\1"`, to work around a bug in `utils::getParseData()` (#25, @michaelchirico)
+  e.g. `"\1"`, to work around a bug (in R<4.2.1) in `utils::getParseData()`
+  (#25, @michaelchirico).
 
 * New `expr_as_xml()` to get an XML representation of R expressions (#27 @MichaelChirico).
 


### PR DESCRIPTION
[r82185](https://bugs.r-project.org/show_bug.cgi?id=18323#c5) was Apr 15, 2022, and R4.2.0 was Apr 22, 2022, I am guessing that the bug is still present in 4.2.0 but fixed for 4.2.1 (I don't have/know of an easy way to confirm this).