### PR TITLE
Speed up map_token

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -169,8 +169,9 @@ fix_comments <- function(pd) {
 }
 
 map_token <- function(token) {
-  map <- xml_parse_token_map[token]
-  ifelse(is.na(map), token, map)
+  needs_translation <- token %in% names(xml_parse_token_map)
+  token[needs_translation] <- xml_parse_token_map[token[needs_translation]]
+  token
 }
 
 #' Map token names of the R parser to token names in


### PR DESCRIPTION
I found `lintr::get_source_expressions()` very slow on the file mentioned on the {cyclocomp} performance issue:

https://github.com/gaborcsardi/cyclocomp/issues/25

It looks like a lot of the time is consumed in `xml_parse_data()` so I'm looking for some easy performance wins.

Avoiding `ifelse()` seems like a good start. Here's a timing comparison of `map_token()` on the parse data frame from that file:

```r
microbenchmark(times = 100, map_token(pd$token), map_token2(pd$token), map_token3(pd$token))
# Unit: milliseconds
#                  expr       min        lq     mean   median       uq       max neval cld
#   map_token(pd$token) 63.981255 67.672844 82.52606 82.72643 87.92059 255.91049   100   c
#  map_token2(pd$token) 24.273721 25.416668 33.79148 28.09598 43.07010  54.56177   100  b 
#  map_token3(pd$token)  9.595289  9.883199 16.86150 10.09418 11.46993 198.82841   100 a  
```

`map_token3()` is implemented here. `map_token2()` is closer to the original:

```r
map_token2 <- function(token) {
  map <- xml_parse_token_map[token]
  translated <- !is.na(map)
  token[translated] <- map[translated]
  token
}
```

So I think we've got an 8x speed-up without much change to readability (IMO readability has improved).