### PR TITLE
Avoid making row names for efficiency

### DIFF
--- a/R/package.R
+++ b/R/package.R
@@ -117,7 +117,8 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
       ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
     )
   } else {
-    pd$tag <- paste0(
+    pd$tag <-
+    tag <- paste0(
       "<", pd$token,
       " line1=\"", pd$line1,
       "\" col1=\"", pd$col1,
@@ -126,9 +127,9 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
       "\" start=\"", pd$start,
       "\" end=\"", pd$end,
       "\">",
-      if (!is.null(pd$text)) xml_encode(pd$text) else "",
-      ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
+      if (!is.null(pd$text)) xml_encode(pd$text) else ""
     )
+    tag[pd$terminal] <- paste0("</", pd$token[pd$terminal], ">")
   }
 
   ## Add an extra terminal tag for each non-terminal one
@@ -141,7 +142,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
     pd2$line2 <- pd2$line2 - 1L
     pd2$col2 <- pd2$col2 - 1L
     pd2$tag <- paste0("</", pd2$token, ">")
-    pd <- rbind(pd, pd2)
+    pd <- rbind(pd, pd2, make.row.names = FALSE)
   }
 
   ## Order the nodes properly

--- a/R/package.R
+++ b/R/package.R
@@ -117,8 +117,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
       ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
     )
   } else {
-    pd$tag <-
-    tag <- paste0(
+    pd$tag <- paste0(
       "<", pd$token,
       " line1=\"", pd$line1,
       "\" col1=\"", pd$col1,
@@ -127,9 +126,9 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
       "\" start=\"", pd$start,
       "\" end=\"", pd$end,
       "\">",
-      if (!is.null(pd$text)) xml_encode(pd$text) else ""
+      if (!is.null(pd$text)) xml_encode(pd$text) else "",
+      ifelse(pd$terminal, paste0("</", pd$token, ">"), "")
     )
-    tag[pd$terminal] <- paste0("</", pd$token[pd$terminal], ">")
   }
 
   ## Add an extra terminal tag for each non-terminal one


### PR DESCRIPTION
Similar to #37, here is an easy win.

We don't care about `pd`'s row names, so skip this expensive part of `rbind()` for a free 6x speed-up:

```r
microbenchmark(times = 100, rbind(pd, pd2), rbind(pd, pd2, make.row.names = FALSE))
# Unit: milliseconds
#                                    expr       min        lq     mean    median       uq      max neval cld
#                          rbind(pd, pd2) 304.47832 338.75108 383.7038 359.57720 418.1269 781.8630   100   b
#  rbind(pd, pd2, make.row.names = FALSE)  58.15727  61.33334 103.1988  63.85209 138.8257 576.0914   100  a 
```