### PR TITLE
Added 'attributes = TRUE' to xml_parse_data(). Set to 'FALSE' to remove XML attributes.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,4 +24,4 @@ Config/testthat/edition: 3
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2

--- a/R/package.R
+++ b/R/package.R
@@ -42,6 +42,7 @@ NULL
 #'
 #' @param pretty Whether to pretty-indent the XML output. It has a small
 #'   overhead which probably only matters for very large source files.
+#' @param attributes Whether to include location tag attributes (`line1`, `col1`, ...)
 #' @inheritParams utils::getParseData
 #' @return An XML string representing the parse data. See details below.
 #'
@@ -58,7 +59,7 @@ NULL
 #' getParseData(expr)
 #'
 #' cat(xml_parse_data(expr, pretty = TRUE))
-xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
+xml_parse_data <- function(x, includeText = NA, pretty = FALSE, attributes = TRUE) {
   xml_header <- paste0(
     "<?xml version=\"1.0\" encoding=\"UTF-8\" ",
     "standalone=\"yes\" ?>\n<exprlist>\n"
@@ -112,7 +113,7 @@ xml_parse_data <- function(x, includeText = NA, pretty = FALSE) {
 
   terminal_tag <- character(nrow(pd))
   terminal_tag[pd$terminal] <- paste0("</", pd$token[pd$terminal], ">")
-  if (anyNA(pd$line1)) {
+  if ((!attributes) || anyNA(pd$line1)) {
     pd$tag <- paste0(
       "<", pd$token, ">",
       if (!is.null(pd$text)) xml_encode(pd$text) else "",

--- a/man/xml_parse_data.Rd
+++ b/man/xml_parse_data.Rd
@@ -4,7 +4,7 @@
 \alias{xml_parse_data}
 \title{Convert R parse data to XML}
 \usage{
-xml_parse_data(x, includeText = NA, pretty = FALSE)
+xml_parse_data(x, includeText = NA, pretty = FALSE, attributes = TRUE)
 }
 \arguments{
 \item{x}{
@@ -18,6 +18,8 @@ xml_parse_data(x, includeText = NA, pretty = FALSE)
 
 \item{pretty}{Whether to pretty-indent the XML output. It has a small
 overhead which probably only matters for very large source files.}
+
+\item{attributes}{Whether to include location tag attributes (\code{line1}, \code{col1}, ...)}
 }
 \value{
 An XML string representing the parse data. See details below.

--- a/man/xmlparsedata-package.Rd
+++ b/man/xmlparsedata-package.Rd
@@ -3,7 +3,6 @@
 \docType{package}
 \name{xmlparsedata-package}
 \alias{xmlparsedata-package}
-\alias{_PACKAGE}
 \title{xmlparsedata: Parse Data of 'R' Code as an 'XML' Tree}
 \description{
 Convert the output of 'utils::getParseData()' to an 'XML' tree, that one can search via 'XPath', and easier to manipulate in general.

--- a/man/xmlparsedata.Rd
+++ b/man/xmlparsedata.Rd
@@ -8,3 +8,22 @@
 Convert the output of 'utils::getParseData()' to an 'XML' tree, that is
 searchable and easier to manipulate in general.
 }
+\seealso{
+Useful links:
+\itemize{
+  \item \url{https://github.com/r-lib/xmlparsedata#readme}
+  \item \url{https://r-lib.github.io/xmlparsedata/}
+  \item Report bugs at \url{https://github.com/r-lib/xmlparsedata/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Gábor Csárdi \email{csardi.gabor@gmail.com}
+
+Other contributors:
+\itemize{
+  \item Posit Software, PBC [copyright holder, funder]
+  \item Mango Solutions [copyright holder, funder]
+}
+
+}

--- a/tests/testthat/test-xml_parse_data.R
+++ b/tests/testthat/test-xml_parse_data.R
@@ -155,3 +155,17 @@ test_that("narrow octal strings are parsed correctly", {
   # mixed-length strings
   expect_match(xml_parse_data(parse(text = "foo('\\1',\n  '\n\\2\n')", keep.source = TRUE)), "'[\\]1'.*'\n[\\]2\n'")
 })
+
+test_that("no attributes are added", {
+  xml <- xml_parse_data(parse(text = "# comment\n", keep.source = TRUE), attributes = FALSE)
+  expect_true(is.character(xml))
+  expect_true(length(xml) == 1)
+  expected = paste0(
+    "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\" ?>\n",
+    "<exprlist>\n",
+    "<COMMENT># comment</COMMENT>\n",
+    "</exprlist>\n"
+    )
+  expect_identical(xml, expected)
+  expect_silent(x <- xml2::read_xml(xml))
+})


### PR DESCRIPTION
This PR includes a small change mentioned in #44, upon specifying `attributes = FALSE` in `xml_parse_data()`, the XML attributes (`line1`, `start`, ...) will be removed (or not included to be precise).
This will help me (and perhaps other people) learning Xpath and writing linters.

Includes a simple unit-test.

Also includes an updated roxygen2 to the current latest version (7.3.2). Can revert and rebuild with the original one if this is a problem.